### PR TITLE
Release Download URL update

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - 'feature*'
+      - 'feature/*'
       - 'master'
   schedule:
     - cron: '0 2 * * *'

--- a/README.md
+++ b/README.md
@@ -18,21 +18,21 @@ Available variables are listed below (located in `defaults/main.yml`):
 tfsec_app: tfsec
 tfsec_version: 0.45.3
 tfsec_osarch: linux-amd64
-tfsec_dl_url: https://github.com/liamg/{{ tfsec_app }}/releases/download/v{{ tfsec_version }}/{{ tfsec_app }}-{{ tfsec_osarch }}
+tfsec_dl_url: https://github.com/aquasecurity/{{ tfsec_app }}/releases/download/v{{ tfsec_version }}/{{ tfsec_app }}-{{ tfsec_osarch }}
 tfsec_bin_path: "/usr/local/bin/{{ tfsec_app }}"
 tfsec_bin_permission_mode: '0755'
 ```
 
 ### Variables table:
 
-Variable                  | Value (default)                                                                                                      | Description
-------------------------- | -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------
-tfsec_app                 | tfsec                                                                                                                | Defines the app to install i.e. **tfsec**
-tfsec_version             | 0.45.3                                                                                                               | Defined to dynamically fetch the desired version to install. Defaults to: **0.45.3**
-tfsec_osarch              | linux-amd64                                                                                                          | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture. Defaults to: **linux-amd64**
-tfsec_dl_url              | <https://github.com/liamg/{{> tfsec_app }}/releases/download/v{{ tfsec_version }}/{{ tfsec_app }}-{{ tfsec_osarch }} | Defines URL to download the tfsec binary from.
-tfsec_bin_path            | "/usr/local/bin/{{ tfsec_app }}"                                                                                     | Defined to dynamically set the appropriate path to store tfsec binary into. Defaults to (as generally available on any user's PATH): **/usr/local/bin/tfsec**
-tfsec_bin_permission_mode | '0755'                                                                                                               | Defines the permission mode level for the file.
+Variable                  | Value (default)                                                                                                               | Description
+------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------
+tfsec_app                 | tfsec                                                                                                                         | Defines the app to install i.e. **tfsec**
+tfsec_version             | 0.45.3                                                                                                                        | Defined to dynamically fetch the desired version to install. Defaults to: **0.45.3**
+tfsec_osarch              | linux-amd64                                                                                                                   | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture. Defaults to: **linux-amd64**
+tfsec_dl_url              | "https://github.com/aquasecurity/{{ tfsec_app }}/releases/download/v{{ tfsec_version }}/{{ tfsec_app }}-{{ tfsec_osarch }}" | Defines URL to download the tfsec binary from.
+tfsec_bin_path            | "/usr/local/bin/{{ tfsec_app }}"                                                                                              | Defined to dynamically set the appropriate path to store tfsec binary into. Defaults to (as generally available on any user's PATH): **/usr/local/bin/tfsec**
+tfsec_bin_permission_mode | '0755'                                                                                                                        | Defines the permission mode level for the file.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,6 @@
 tfsec_app: tfsec
 tfsec_version: 0.45.3
 tfsec_osarch: linux-amd64
-tfsec_dl_url: https://github.com/liamg/{{ tfsec_app }}/releases/download/v{{ tfsec_version }}/{{ tfsec_app }}-{{ tfsec_osarch }}
+tfsec_dl_url: https://github.com/aquasecurity/{{ tfsec_app }}/releases/download/v{{ tfsec_version }}/{{ tfsec_app }}-{{ tfsec_osarch }}
 tfsec_bin_path: "/usr/local/bin/{{ tfsec_app }}"
 tfsec_bin_permission_mode: '0755'


### PR DESCRIPTION
* Update of `tfsec_dl_url` as repository/releases moved over to AquaSecurity Organization